### PR TITLE
chore: drop llama-cpp-python

### DIFF
--- a/nix/pyproject-overrides.nix
+++ b/nix/pyproject-overrides.nix
@@ -13,18 +13,6 @@
       hatchling = prev.hatchling.overrideAttrs (attrs: {
         propagatedBuildInputs = attrs.propagatedBuildInputs or [ ] ++ [ final.editables ];
       });
-      llama-cpp-python = prev.llama-cpp-python.overrideAttrs (attrs: {
-        CMAKE_ARGS = [ "-DLLAMA_BUILD=OFF" ];
-        propagatedBuildInputs = attrs.propagatedBuildInputs or [ ] ++ [
-          pkgs.cmake
-          pkgs.git
-        ];
-        nativeBuildInputs =
-          attrs.nativeBuildInputs or [ ]
-          ++ (final.resolveBuildSystem {
-            scikit-build-core = [ ];
-          });
-      });
       torch = prev.torch.overrideAttrs (attrs: {
         buildInputs =
           if (withCUDA) then

--- a/nix/utils.nix
+++ b/nix/utils.nix
@@ -148,8 +148,6 @@ let
         export UV_NO_SYNC=1
         # Stop uv from downloading python
         export UV_PYTHON_DOWNLOADS=never
-        # llama.cpp
-        export LLAMA_CPP_LIB_PATH=${pkgs.llama-cpp.override { cudaSupport = withCUDA; }}/lib
       '';
     });
 in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ requires-python = ">=3.12"
 dependencies = [
     "fastapi[standard]>=0.115.12",
     "httpx>=0.28.1",
-    "llama-cpp-python>=0.3.8",
     "openai>=1.73.0",
     "pydantic-settings>=2.8.1",
     "sympy>=1.13.1",

--- a/uv.lock
+++ b/uv.lock
@@ -148,15 +148,6 @@ wheels = [
 ]
 
 [[package]]
-name = "diskcache"
-version = "5.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
-]
-
-[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -424,7 +415,6 @@ source = { editable = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"], marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-5-laime-cpu' and extra == 'extra-5-laime-cuda')" },
     { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-5-laime-cpu' and extra == 'extra-5-laime-cuda')" },
-    { name = "llama-cpp-python", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-5-laime-cpu' and extra == 'extra-5-laime-cuda')" },
     { name = "openai", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-5-laime-cpu' and extra == 'extra-5-laime-cuda')" },
     { name = "pydantic-settings", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-5-laime-cpu' and extra == 'extra-5-laime-cuda')" },
     { name = "sympy", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-5-laime-cpu' and extra == 'extra-5-laime-cuda')" },
@@ -454,7 +444,6 @@ dev = [
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "llama-cpp-python", specifier = ">=0.3.8" },
     { name = "openai", specifier = ">=1.73.0" },
     { name = "pydantic-settings", specifier = ">=2.8.1" },
     { name = "sentence-transformers", marker = "extra == 'cpu'", specifier = ">=4.0.2" },
@@ -474,18 +463,6 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "ruff", specifier = ">=0.11.3" },
 ]
-
-[[package]]
-name = "llama-cpp-python"
-version = "0.3.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "diskcache", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-5-laime-cpu' and extra == 'extra-5-laime-cuda')" },
-    { name = "jinja2", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-5-laime-cpu' and extra == 'extra-5-laime-cuda')" },
-    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-5-laime-cpu' and extra == 'extra-5-laime-cuda')" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or (extra == 'extra-5-laime-cpu' and extra == 'extra-5-laime-cuda')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/de/6d/4a20e676bdf7d9d3523be3a081bf327af958f9bdfe2a564f5cf485faeaec/llama_cpp_python-0.3.9.tar.gz", hash = "sha256:a3a985f558385e2f5de5b663f4e9b0817506d6af98122450142cd98e79216370", size = 67858575, upload-time = "2025-05-08T11:12:05.992Z" }
 
 [[package]]
 name = "markupsafe"


### PR DESCRIPTION
Most of what i thought we needed this for is in the `llama-server` binary provided with llama.cpp.