### PR TITLE
fix(llama-server): catch connection errors in the healthcheck

### DIFF
--- a/src/laime/backends/llama_cpp.py
+++ b/src/laime/backends/llama_cpp.py
@@ -63,8 +63,11 @@ class LlamaServerBackend(
 		)
 		_ = atexit.register(self.__del__)
 		while True:
-			if httpx.get(f"http://localhost:{self.port}/health").status_code == 200:
-				break
+			try:
+				if httpx.get(f"http://localhost:{self.port}/health").status_code == 200:
+					break
+			except httpx.ConnectError:  # pragma: no cover
+				pass
 
 	@override
 	async def embed(self, input: str) -> list[float]:


### PR DESCRIPTION
If the server takes a bit of time to start accepting requests, the healthcheck breaks.